### PR TITLE
Remove dependencies to sample_app

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ include_directories(fsw/mission_inc)
 include_directories(fsw/platform_inc)
 include_directories(${ci_lab_MISSION_DIR}/fsw/platform_inc)
 include_directories(${to_lab_MISSION_DIR}/fsw/platform_inc)
-include_directories(${sample_app_MISSION_DIR}/fsw/platform_inc)
 
 # Create the app module
 add_cfe_app(sch_lab fsw/src/sch_lab_app.c)

--- a/fsw/platform_inc/sch_lab_sched_tab.h
+++ b/fsw/platform_inc/sch_lab_sched_tab.h
@@ -38,8 +38,6 @@
 #include "ci_lab_msgids.h"
 #include "to_lab_msgids.h"
 
-#include "sample_app_msgids.h"
-
 #if 0
 #include "sc_msgids.h"
 #include "hs_msgids.h"

--- a/fsw/src/sch_lab_table.c
+++ b/fsw/src/sch_lab_table.c
@@ -41,7 +41,6 @@ SCH_LAB_ScheduleTable_t SCH_TBL_Structure = {.Config = {
                                                  {CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_SEND_HK_MID), 4},
                                                  {CFE_SB_MSGID_WRAP_VALUE(CI_LAB_SEND_HK_MID), 4},
                                                  {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_SEND_HK_MID), 4},
-                                                 {CFE_SB_MSGID_WRAP_VALUE(SAMPLE_APP_SEND_HK_MID), 4},
 #if 0
                 {CFE_SB_MSGID_WRAP_VALUE(SC_SEND_HK_MID),       4},
                 {CFE_SB_MSGID_WRAP_VALUE(SC_1HZ_WAKEUP_MID),    1},  /* Example of a 1hz packet */


### PR DESCRIPTION
Since the `sample_app` and the `sample_lib` will not be included in our flight repo, dependencies to them are removed from the code.